### PR TITLE
Fixed typo,  simplified comment inline, and add the writer info header to create functionality

### DIFF
--- a/src/app/resolvers/comment_req.py
+++ b/src/app/resolvers/comment_req.py
@@ -1,7 +1,6 @@
 from flask import make_response
 from jama import comment
 from slack import tools
-from jama.tools import make_dict
 from jama.tools import commands_info
 from jama.tools import api_error
 from slack.slack_json_factories.dialog_json import comment as dialog
@@ -42,15 +41,7 @@ def resolve(base_url, content, slack_client, request):
                 dialog=dialog.comment_dialog()
             )
         else:
-            args = make_dict(content)
-            if "id" not in args or "comment" not in args:
-                return commands_info.comment(request, "Oh no, there was an error with your inputs!")
-
-            comment_create_response = comment.from_inline(slack_team_id,
-                                                          slack_user_id,
-                                                          base_url,
-                                                          args
-                                                          )
+            comment_create_response = comment.from_inline(slack_team_id, slack_user_id, base_url, content)
             tools.return_to_slack(request, comment_create_response)
         return make_response("", 200)
 

--- a/src/app/route_handler.py
+++ b/src/app/route_handler.py
@@ -193,13 +193,15 @@ def resolve_jama_req(base_url, req):
     else:
         # If input from user is buggy
         content = req.form["text"].strip()
-        if "comment" in content:
-            return commands_info.comment(request)
-        elif "create" in content:
+        if content.startswith("comment"):
+            return commands_info.comment(request,
+            headline="There was an error with your command! Here is a quick guide to using `/jamaconnect comment`:")
+        elif content.startswith("create"):
             return commands_info.create(request,
             headline="There was an error with your command! Here is a quick guide to using `/jamaconnect create`:")
-        elif "search" in content:
-            return commands_info.search(request)
+        elif content.startswith("search"):
+            return commands_info.search(request,
+            headline="There was an error with your command! Here is a quick guide to using `/jamaconnect search`:")
         else:
             return commands_info.all(request)
 

--- a/src/jama/comment/comment.py
+++ b/src/jama/comment/comment.py
@@ -42,25 +42,25 @@ def from_dialog(base_url, payload):
     slack_user_id = payload["user"]["id"]
     if (slack_team_id, slack_user_id) in user_project_id_list:
         del user_project_id_list[(slack_team_id, slack_user_id)]
-    return comment(base_url, slack_team_id, slack_user_id, post_id, comment_body)
+    return to_jama(base_url, slack_team_id, slack_user_id, post_id, comment_body)
 
 
-def from_inline(slack_team_id, slack_user_id, base_url, args):
+def from_inline(slack_team_id, slack_user_id, base_url, content):
     """
     Process input from slack massage and sent them to comment()
     Args:
         slack_team_id (string): The slack team ID
         slack_user_id (string): The slack User ID, which is not the username!
         base_url (string): The Jama workspace base_url
-        args (dict): the user input content which is cut at routes.py
+        content (string): the user input content
     Returns:
         (dict): Returns JSON object with commented item url and status
     """
-    # str_post_id, comment_body = tools.cutArgument(content, ",")
-    return comment(base_url, slack_team_id, slack_user_id, args["id"], args["comment"])
+    str_post_id, comment_body = tools.cutArgument(content, "|")
+    return to_jama(base_url, slack_team_id, slack_user_id, str_post_id, comment_body)
 
 
-def comment(base_url, team_id, user_id, str_post_id, comment_body):
+def to_jama(base_url, team_id, user_id, str_post_id, comment_body):
     """
     Comment by passing URL routes with query string
     Args:
@@ -199,6 +199,7 @@ def dynamic_item_list(base_url, keyword, teamID, userID, state):
         keyword (string): keyword of the item
         teamID (string): Slack team ID
         userID (string): Slack user ID
+        state (string): The id of the project which user want to search.
     Returns:
         (dict): Returns JSONed object of options to slack
     """

--- a/src/jama/comment/comment.py
+++ b/src/jama/comment/comment.py
@@ -280,7 +280,7 @@ def dynamic_item_list(base_url, keyword, teamID, userID, state):
             index += 50
             if index >= total_results:
                 break
-            jama_json_response = jama_tools.search_item(base_url, project_id, index, keyword)
+            jama_json_response = jama_tools.search_item(base_url, project_id, index, keyword, teamID, userID)
             result_count = jama_json_response["meta"]["pageInfo"]["resultCount"]
         slack_payload = {
             "options": options_filtered[:100]

--- a/src/jama/create/create.py
+++ b/src/jama/create/create.py
@@ -53,7 +53,7 @@ def from_dialog(url_base, json_to_parse):
 
         jama_resp = api_caller.post(team_id, user_id, jama_url, payload=to_post_obj)
         if jama_resp is None:
-            raise Exception("Invaid oauth credentials")
+            raise Exception("Invalid oauth credentials")
 
         return created_item.resp_json(jama_resp, to_post_obj["project"])
     except Exception as err:
@@ -64,7 +64,7 @@ def from_dialog(url_base, json_to_parse):
                 "attachments": [
                     {
                         "text": """Please update your oauth credentials and give it another go!
-                        If it doens't work, please submit a bug report"""
+                        If it doesn't work, please submit a bug report"""
                     }
                 ]
             }

--- a/src/jama/create/create.py
+++ b/src/jama/create/create.py
@@ -1,19 +1,15 @@
-import os
-import json
-import requests
 from flask import make_response
 from jama.json_factories import item_factory
-from jama import oauth
+from jama import tools as jama_tools
 from jama import api_caller
 from slack.slack_json_factories.resp_json import created_item
 from slack import tools
-from pprint import pprint
 
 """create.py == Backbone of create functionality
 
 There are two main functionalities present in this file:
-    1. Recieving formatted data from a dialog in Slack and posting to Jama
-    2. Recieving filtered/formatted data from text interface and posting to Jama
+    1. Receiving formatted data from a dialog in Slack and posting to Jama
+    2. Receiving filtered/formatted data from text interface and posting to Jama
 
 As the file name is states, these functions are the backbone for the ability to create
 an item from data that is input in Slack.
@@ -27,7 +23,7 @@ def from_dialog(url_base, json_to_parse):
     
     Args:
         url_base (string): base url for jama instance
-        json_to_parse (string): slack json submission
+        json_to_parse (dict): slack json submission
 
     Returns:
         (dict): Returns JSON object with created item url and status
@@ -47,7 +43,13 @@ def from_dialog(url_base, json_to_parse):
         to_post_obj["location"]["parent"]["item"] = int(parentId)
         to_post_obj["itemType"] = int(item_type)
         to_post_obj["fields"]["name"] = sub_data["newItemName"]
-        to_post_obj["fields"]["description"] = sub_data["description"]
+
+        # If the server do not use Jama OAuth, add a header to indicate who is the poster
+        if api_caller.is_using_oauth():
+            to_post_obj["fields"]["description"] = tools.prepare_html(sub_data["description"])
+        else:
+            header = jama_tools.prepare_writer_info(team_id, user_id, url_base, False)
+            to_post_obj["fields"]["description"] = tools.prepare_html(header + sub_data["description"])
 
         jama_resp = api_caller.post(team_id, user_id, jama_url, payload=to_post_obj)
         if jama_resp is None:
@@ -72,7 +74,7 @@ def from_dialog(url_base, json_to_parse):
                     "attachments": [
                         {
                             "text": """Please give it another go!
-                            If it doens't work, please submit a bug report"""
+                            If it doesn't work, please submit a bug report"""
                         }
                     ]
                 }
@@ -120,6 +122,14 @@ If a field is an ID (e.g. projectID), it needs to be a number. Otherwise, it can
     user_id = content_dict["user"]["id"]
 
     try:
+        # If the server do not use Jama OAuth, add a header to indicate who is the poster
+        if "description" in content_dict:
+            if api_caller.is_using_oauth():
+                content_dict["description"] = tools.prepare_html(content_dict["description"])
+            else:
+                header = jama_tools.prepare_writer_info(team_id, user_id, base_url, False)
+                content_dict["description"] = tools.prepare_html(header + content_dict["description"])
+
         for key in content_dict:
             # Some keys need to be ints
             # specifically project, item, itemType
@@ -160,7 +170,7 @@ If a field is an ID (e.g. projectID), it needs to be a number. Otherwise, it can
     jama_url = base_url + '/rest/latest/items/'
     jama_resp = api_caller.post(team_id, user_id, jama_url, payload=to_post_obj)
     if jama_resp is None:
-        raise Exception("Invaid oauth credentials")
+        raise Exception("Invalid oauth credentials")
 
     # Returns json object w/ url of new item
     return created_item.resp_json(jama_resp, to_post_obj["project"])

--- a/src/jama/tools/writer_information.py
+++ b/src/jama/tools/writer_information.py
@@ -21,11 +21,12 @@ def prepare_writer_info(slack_team_id, slack_user_id, jama_base_url, use_at_user
         found, jama_user_info = tools.get_user_by_email(jama_base_url,
                                                         slack_team_id,
                                                         slack_user_id,
-                                                        slack_user_info["email"])
+                                                        slack_user_info["email"]
+                                                        )
         if found:
             # prepare a html code for posting on Jama
             if use_at_user:
-                return "Jama user" + prepare_jama_mention(jama_user_info) + " post:\n"
+                return "Jama user " + prepare_jama_mention(jama_user_info) + " post:\n"
             else:
                 return "Jama user @" + jama_user_info["username"] + " post:\n"
         # prepare a html code for posting on Jama

--- a/src/slack/slack_json_factories/resp_json/attachment.py
+++ b/src/slack/slack_json_factories/resp_json/attachment.py
@@ -28,11 +28,11 @@ def attachment_fail_response(item_id, description, response=None):
     }
     # Base on the return data from Jama, give user some detail of the posting result.
     if response is None:
-        resp["attachments"][1]["title"] = "Error Massage"
+        resp["attachments"][1]["title"] = "Error Message"
         resp["attachments"][1]["text"] = "User's Oauth token is invalid or server is down. Please check again."
     else:
         resp["text"] = "Error"
-        resp["attachments"][1]["title"] = "Error Massage from Jama"
+        resp["attachments"][1]["title"] = "Error Message from Jama"
         resp["attachments"][1]["text"] = "Status: " + response["meta"]["status"] +\
                                          "\nMessage: " + response["meta"]["message"]
     return resp
@@ -78,7 +78,7 @@ def file_failure_response():
         "attachments": [
             {
                 "color": "danger",
-                "title": "Error Massage",
+                "title": "Error Message",
                 "text": "The message you choose has no file or the file cannot be uploaded. Please check again."
             }
         ]

--- a/src/slack/slack_json_factories/resp_json/comment.py
+++ b/src/slack/slack_json_factories/resp_json/comment.py
@@ -11,9 +11,9 @@ def comment_response(item_id, comment, response=None):
         comment (string): the content user want to put into the comment
         response (dict): The response of jama API post /comment. This is not required if there is no response
                          from Jama. In this case, this function would assume the API calling process is stopped
-                         because of invalid user input and create an error massage.
+                         because of invalid user input and create an error message.
     Returns:
-        (dict): A JSon object of a slack massage, which shows the status of the Jama comment.
+        (dict): A JSon object of a slack message, which shows the status of the Jama comment.
     """
     # Base json for returning to slack
     resp = {
@@ -35,7 +35,7 @@ def comment_response(item_id, comment, response=None):
     # because of the input. This function should check the input and give proper response.
     if response is None:
         resp["text"] = "Bad Request"
-        resp["attachments"][1]["title"] = "Error Massage"
+        resp["attachments"][1]["title"] = "Error Message"
         if tools.string_to_int(item_id) < 0:
             resp["attachments"][1]["text"] += "The item id `" + item_id + "` is invalid.\n"
         if comment is "":
@@ -54,9 +54,9 @@ def comment_response(item_id, comment, response=None):
         resp["attachments"][1]["title"] = "Url to commented item"
         resp["attachments"][1]["text"] = "https://capstone-test.jamacloud.com/perspective.req#/items/" + item_id
     elif response["meta"]["status"] == "Not Found":
-        resp["attachments"][1]["title"] = "Error Massage"
+        resp["attachments"][1]["title"] = "Error Message"
         resp["attachments"][1]["text"] = "The item id `" + item_id + "` is not found. Please check again."
     else:
-        resp["attachments"][1]["title"] = "Error Massage"
-        resp["attachments"][1]["text"] = "Error massage from Jama: " + response["meta"]["message"]
+        resp["attachments"][1]["title"] = "Error Message"
+        resp["attachments"][1]["text"] = "Error message from Jama: " + response["meta"]["message"]
     return resp


### PR DESCRIPTION
1. Fixed typo in 

`src/slack/slack_json_factories/resp_json/attachment.py`

`src/slack/slack_json_factories/resp_json/comment.py`

`src/jama/create/create.py`

2. Roll back to simple comment inline.
Now you can use `/jamaconnect comment:<itemID>|<commentBody>` to create a comment.

3. Add the writer info header to create functionality
If the server does not use Jama OAuth, a header would display in the item description to shows the true creator. 

4. Remove unused library in `src/jama/create/create.py`

5. In `src/app/route_handler.py` line 194-206, when user has some invalid input and our code need to return some suggestion, our code would try to find the command base on the beginning of the invalid input.

For example, if the user input is the command below:

`/jamaconnect create project=48| name=Bugs in comment functionality`

This command would cause error because it is missing a ":" sign after `create`. Thus, our code need to return a suggestion of how to use the `create` command.

For the example above, the user is probably trying to use `create` command. However, the current version would try to find `comment` in the string first. Because there is a "comment" is in the name section, our code would guess the user want to use `command` and return a suggestion of how to use `comment` command.

After my change, our code would try to match the command at the beginning of the string. For the example above, it would return the suggestion of how to use `create` command.